### PR TITLE
[WIP] plot_age_pyramid: add the possibility to have one datetime_ref that differs for each patient

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## v0.1.3 (2022-12-06)
+## Pending
+
+### Added
 
 - Adding person-dependant `datetime_ref` to `plot_age_pyramid`
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.3 (2022-12-06)
+
+- Adding person-dependant `datetime_ref` to `plot_age_pyramid`
+
 ## v0.1.2 (2022-12-05)
 
 ### Added

--- a/eds_scikit/plot/data_quality.py
+++ b/eds_scikit/plot/data_quality.py
@@ -109,7 +109,7 @@ def plot_age_pyramid(
 
     group = group.to_frame().reset_index()
     group["age_bins"] = (
-        person["age_bins"].astype(str).str.lower().str.replace("nan", "90+")
+        group["age_bins"].astype(str).str.lower().str.replace("nan", "90+")
     )
 
     male = group.loc[group["gender_source_value"] == "m"].reset_index()

--- a/eds_scikit/plot/data_quality.py
+++ b/eds_scikit/plot/data_quality.py
@@ -1,10 +1,11 @@
 from copy import copy
 from datetime import datetime
-from typing import Optional, Tuple, Union
+from typing import Tuple, Union
 
 import altair as alt
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_integer_dtype
 from pandas.core.frame import DataFrame
 from pandas.core.series import Series
 
@@ -14,7 +15,7 @@ from ..utils.framework import bd
 
 def plot_age_pyramid(
     person: DataFrame,
-    datetime_ref: datetime = None,
+    datetime_ref: Union[datetime, str] = None,
     filename: str = None,
     savefig: bool = False,
     return_vector: bool = False,
@@ -57,15 +58,15 @@ def plot_age_pyramid(
             raise ValueError("You have to set a filename")
         if not isinstance(filename, str):
             raise ValueError(f"'filename' type must be str, got {type(filename)}")
-    datetime_ref_raw = copy(datetime_ref)
-    person_ = person.copy()
+    datetime_ref_original = copy(datetime_ref)
+
     if datetime_ref is None:
         datetime_ref = datetime.today()
     elif isinstance(datetime_ref, datetime):
         datetime_ref = pd.to_datetime(datetime_ref)
     elif isinstance(datetime_ref, str):
-        if datetime_ref in person_.columns:
-            datetime_ref = person_[datetime_ref]
+        if datetime_ref in person.columns:
+            datetime_ref = person[datetime_ref]
         else:
             datetime_ref = pd.to_datetime(
                 datetime_ref, errors="coerce"
@@ -73,32 +74,45 @@ def plot_age_pyramid(
             if pd.isnull(datetime_ref):
                 raise ValueError(
                     f"`datetime_ref` must either be a column name or parseable date, "
-                    f"got string '{datetime_ref_raw}'"
+                    f"got string '{datetime_ref_original}'"
                 )
     else:
         raise TypeError(
             f"`datetime_ref` must be either None, a parseable string date"
             f", a column name or a datetime. Got type: {type(datetime_ref)}, {datetime_ref}"
         )
-    person_["age"] = (datetime_ref - person_["birth_datetime"]).dt.total_seconds()
-    person_["age"] /= 365 * 24 * 3600
+
+    person = person.loc[person["gender_source_value"].isin(["m", "f"])]
+
+    deltas = datetime_ref - person["birth_datetime"]
+    if not is_integer_dtype(deltas):
+        deltas = deltas.dt.total_seconds()
+    person["age"] = deltas / 365 * 24 * 3600
 
     bins = np.arange(0, 100, 10)
     labels = [f"{left}-{right}" for left, right in zip(bins[:-1], bins[1:])]
-    person_["age_bins"] = bd.cut(person_["age"], bins=bins, labels=labels)
 
-    person_["age_bins"] = (
-        person_["age_bins"].astype(str).str.lower().str.replace("nan", "90+")
-    )
+    # This is equivalent to `pd.cut()` for pandas and this call our custom `cut`
+    # implementation for koalas.
+    person["age_bins"] = bd.cut(person["age"], bins=bins, labels=labels)
 
-    person_ = person_.loc[person_["gender_source_value"].isin(["m", "f"])]
-    group_gender_age = person_.groupby(["gender_source_value", "age_bins"])[
+    # This is equivalent to `person.cache()` for koalas and this is a no-op
+    # for pandas.
+    # Cache the intermediate results of the transformation so that other transformation
+    # runs on top of cached will perform faster.
+    # TODO: try to remove it and check perfs.
+    bd.cache(person)
+
+    group_gender_age = person.groupby(["gender_source_value", "age_bins"])[
         "person_id"
     ].count()
 
     # Convert to pandas to ease plotting.
-    # Since we have aggregated the data, this operation won't crash.
     group_gender_age = bd.to_pandas(group_gender_age)
+
+    group_gender_age["age_bins"] = (
+        person["age_bins"].astype(str).str.lower().str.replace("nan", "90+")
+    )
 
     male = group_gender_age["m"].reset_index()
     female = group_gender_age["f"].reset_index()

--- a/eds_scikit/utils/custom_implem/custom_implem.py
+++ b/eds_scikit/utils/custom_implem/custom_implem.py
@@ -14,6 +14,17 @@ class CustomImplem:
     """
 
     @classmethod
+    def cache(cls, obj: DataFrame, backend=None) -> None:
+        """Run df.cache() for Koalas. No-op for pandas."""
+        if backend is pd:
+            return
+        elif backend is ks:
+            obj.spark.cache()
+            return
+        else:
+            raise ValueError(f"Unknown backend {backend}")
+
+    @classmethod
     def add_unique_id(
         cls,
         obj: DataFrame,
@@ -27,9 +38,7 @@ class CustomImplem:
         elif backend is ks:
             return obj.koalas.attach_id_column(id_type="distributed", column=col_name)
         else:
-            raise NotImplementedError(
-                f"No method 'add_unique_id' is available for backend '{backend}'."
-            )
+            raise ValueError(f"Unknown backend {backend}")
 
     @classmethod
     def cut(

--- a/tests/test_age_pyramid.py
+++ b/tests/test_age_pyramid.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import altair as alt
@@ -8,31 +8,36 @@ from pandas.testing import assert_frame_equal
 
 from eds_scikit.datasets.synthetic.person import load_person
 from eds_scikit.plot.data_quality import plot_age_pyramid
+import pandas as pd 
+import numpy as np
 
 data = load_person()
 
+person_with_inclusion_date = data.person.copy()
+person_with_inclusion_date["inclusion_datetime"] = person_with_inclusion_date["birth_datetime"] + pd.to_timedelta(np.random.randint(0, 1000, len(person_with_inclusion_date)), unit='d')
 
-def test_plot_age_pyramid():
-    original_person = data.person.copy()
-
-    datetime_ref = datetime(2020, 1, 1)
-    chart, group_gender_age = plot_age_pyramid(data.person, datetime_ref, savefig=False)
+@pytest.mark.parametrize(
+    "datetime_ref", [datetime(2020, 1, 1), "inclusion_datetime"]
+    )
+def test_plot_age_pyramid(datetime_ref):
+    original_person = person_with_inclusion_date.copy()
+    chart, group_gender_age = plot_age_pyramid(person_with_inclusion_date, datetime_ref, savefig=False)
     assert isinstance(chart, alt.vegalite.v4.api.ConcatChart)
     assert isinstance(group_gender_age, Series)
 
     # Check that the data is unchanged
-    assert_frame_equal(original_person, data.person)
+    assert_frame_equal(original_person, person_with_inclusion_date)
 
     filename = "test.html"
-    _ = plot_age_pyramid(data.person, savefig=True, filename=filename)
+    _ = plot_age_pyramid(person_with_inclusion_date, savefig=True, filename=filename)
     path = Path(filename)
     assert path.exists()
     path.unlink()
 
     with pytest.raises(ValueError, match="You have to set a filename"):
-        _ = plot_age_pyramid(data.person, savefig=True, filename=None)
+        _ = plot_age_pyramid(person_with_inclusion_date, savefig=True, filename=None)
 
     with pytest.raises(
         ValueError, match="'filename' type must be str, got <class 'list'>"
     ):
-        _ = plot_age_pyramid(data.person, savefig=True, filename=[1])
+        _ = plot_age_pyramid(person_with_inclusion_date, savefig=True, filename=[1])

--- a/tests/test_age_pyramid.py
+++ b/tests/test_age_pyramid.py
@@ -1,27 +1,35 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 
 import altair as alt
+import numpy as np
+import pandas as pd
 import pytest
 from pandas.core.series import Series
 from pandas.testing import assert_frame_equal
 
 from eds_scikit.datasets.synthetic.person import load_person
 from eds_scikit.plot.data_quality import plot_age_pyramid
-import pandas as pd 
-import numpy as np
 
 data = load_person()
 
 person_with_inclusion_date = data.person.copy()
-person_with_inclusion_date["inclusion_datetime"] = person_with_inclusion_date["birth_datetime"] + pd.to_timedelta(np.random.randint(0, 1000, len(person_with_inclusion_date)), unit='d')
+N = len(person_with_inclusion_date)
+delta_days = pd.to_timedelta(np.random.randint(0, 1000, N), unit="d")
+
+person_with_inclusion_date["inclusion_datetime"] = (
+    person_with_inclusion_date["birth_datetime"] + delta_days
+)
+
 
 @pytest.mark.parametrize(
-    "datetime_ref", [datetime(2020, 1, 1), "inclusion_datetime"]
-    )
+    "datetime_ref", [datetime(2020, 1, 1), "inclusion_datetime", "2020-01-01"]
+)
 def test_plot_age_pyramid(datetime_ref):
     original_person = person_with_inclusion_date.copy()
-    chart, group_gender_age = plot_age_pyramid(person_with_inclusion_date, datetime_ref, savefig=False)
+    chart, group_gender_age = plot_age_pyramid(
+        person_with_inclusion_date, datetime_ref, savefig=False
+    )
     assert isinstance(chart, alt.vegalite.v4.api.ConcatChart)
     assert isinstance(group_gender_age, Series)
 
@@ -41,3 +49,20 @@ def test_plot_age_pyramid(datetime_ref):
         ValueError, match="'filename' type must be str, got <class 'list'>"
     ):
         _ = plot_age_pyramid(person_with_inclusion_date, savefig=True, filename=[1])
+
+
+def test_plot_age_pyramid_datetime_ref_error():
+    with pytest.raises(
+        ValueError,
+        match="`datetime_ref` must either be a column name or parseable date, got string '20x2-01-01'",
+    ):
+        _ = plot_age_pyramid(
+            person_with_inclusion_date, datetime_ref="20x2-01-01", savefig=False
+        )
+    with pytest.raises(
+        TypeError,
+        match="`datetime_ref` must be either None, a parseable string date, a column name or a datetime. Got type: <class 'int'>, 2022",
+    ):
+        _ = plot_age_pyramid(
+            person_with_inclusion_date, datetime_ref=2022, savefig=False
+        )

--- a/tests/test_age_pyramid.py
+++ b/tests/test_age_pyramid.py
@@ -5,7 +5,7 @@ import altair as alt
 import numpy as np
 import pandas as pd
 import pytest
-from pandas.core.series import Series
+from pandas.core.frame import DataFrame
 from pandas.testing import assert_frame_equal
 
 from eds_scikit.datasets.synthetic.person import load_person
@@ -45,13 +45,13 @@ def test_age_pyramid_output():
     group_gender_age = plot_age_pyramid(
         data.person, savefig=True, return_vector=True, filename=filename
     )
-    assert isinstance(group_gender_age, Series)
+    assert isinstance(group_gender_age, DataFrame)
 
     chart, group_gender_age = plot_age_pyramid(
         data.person, savefig=False, return_vector=True
     )
     assert isinstance(chart, alt.vegalite.v4.api.ConcatChart)
-    assert isinstance(group_gender_age, Series)
+    assert isinstance(group_gender_age, DataFrame)
 
     chart = plot_age_pyramid(data.person, savefig=False, return_vector=False)
     assert isinstance(chart, alt.vegalite.v4.api.ConcatChart)

--- a/tests/test_age_pyramid.py
+++ b/tests/test_age_pyramid.py
@@ -27,9 +27,7 @@ person_with_inclusion_date["inclusion_datetime"] = (
 )
 def test_plot_age_pyramid(datetime_ref):
     original_person = person_with_inclusion_date.copy()
-    chart = plot_age_pyramid(
-        person_with_inclusion_date, datetime_ref, savefig=False
-    )
+    chart = plot_age_pyramid(person_with_inclusion_date, datetime_ref, savefig=False)
     assert isinstance(chart, alt.vegalite.v4.api.ConcatChart)
 
     # Check that the data is unchanged


### PR DESCRIPTION
The previous plot_age_pyramid function only allow for one fixed datetime reference for all persons. 

In some case studies , we would like to have a different datetime of reference for each person. 
Eg. the date of their inclusion in the study. The objective is to draw the pyramid of ages  of patient at inclusion. (Very useful and more pertinent when we have cohorts over a long time period). 

## Description

Add to plot_age_pyramid the possibility to give the datetime_ref argument as a column name. 

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
