### PR TITLE
FIX I2B2 `get_consultations_date()`

### DIFF
--- a/eds_scikit/io/i2b2_mapping.py
+++ b/eds_scikit/io/i2b2_mapping.py
@@ -112,7 +112,7 @@ def get_i2b2_table(
         )
 
     # Documents
-    elif table == "note":
+    elif table.startswith("note"):
         df = df.withColumn(
             "note_class_source_value",
             F.substring(F.col("note_class_source_value"), 4, 100),

--- a/eds_scikit/utils/custom_implem/custom_implem.py
+++ b/eds_scikit/utils/custom_implem/custom_implem.py
@@ -63,3 +63,16 @@ class CustomImplem:
             duplicates,
             ordered,
         )
+
+    @classmethod
+    def cache(cls, df, backend=None):
+        if backend is pd:
+            # no-op
+            return
+        elif backend is ks:
+            df.spark.cache()
+            return
+        else:
+            raise NotImplementedError(
+                f"No method 'cache' is available for backend '{backend}'."
+            )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Describe the changes. -->
- Add `cache` to the BackendDIspatcher
- Convert `note_datetime` in `get_consultations_date()` into `str` then to `datetime` to avoid bad date format errors in spark.
- Extend I2B2 preprocessing from `note` to `note*` to include `note_deid`

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [ ] If this PR is a bug fix, the bug is documented in the test suite.
- [ ] Changes were documented in the changelog (pending section).
- [ ] If necessary, changes were made to the documentation (eg new pipeline).
