### PR TITLE
small IO and biology fixes

### DIFF
--- a/docs/functionalities/generic/io.ipynb
+++ b/docs/functionalities/generic/io.ipynb
@@ -2,33 +2,51 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "3970914a",
+   "metadata": {},
    "source": [
     "# IO: Getting Data"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "dec9f983",
+   "metadata": {},
    "source": [
     "3 classes are available to facilitate data access:\n",
     "\n",
     "- `HiveData`: Getting data from a Hive cluster, returning `Koalas` DataFrames\n",
     "- `PandasData`: Getting data from tables saved on disk, returning `Pandas` DataFrames\n",
     "- `PostgresData`: Getting data from a PostGreSQL DB, returning `Pandas` DataFrames\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
+   "id": "ad31d102",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-02-08 14:54:26.449 | WARNING  | eds_scikit:<module>:31 - \n",
+      "    To improve performances when using Spark and Koalas, please call `eds_scikit.improve_performances()`\n",
+      "    This function optimally configures Spark. Use it as:\n",
+      "    `spark, sc, sql = eds_scikit.improve_performances()`\n",
+      "    The functions respectively returns a SparkSession, a SparkContext and an sql method\n",
+      "    \n"
+     ]
+    }
+   ],
    "source": [
     "from eds_scikit.io import HiveData, PandasData, PostgresData"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "4810071e",
+   "metadata": {},
    "source": [
     "## Loading from Hive: `HiveData`\n",
     "\n",
@@ -36,11 +54,12 @@
     "\n",
     "- A `SparkSession` variable\n",
     "- The name of the Database to connect to\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "83263eca",
+   "metadata": {},
    "source": [
     "!!! aphp \"Using **Spark** kernels\"\n",
     "     All kernels designed to use Spark are configured to expose 3 variables at startup:  \n",
@@ -53,19 +72,22 @@
     "\n",
     "!!! tip \"Working with an I2B2 database\"\n",
     "     To use a built-in *I2B2 to OMOP* connector, specify `database_type=\"I2b2\"` when instantiating `HiveData`"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "46b71d17",
+   "metadata": {},
    "source": [
     "If needed, the following snippet allows to create the necessary variables:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a3c8ef85",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from pyspark import SparkConf, SparkContext\n",
     "from pyspark.sql.session import SparkSession\n",
@@ -76,82 +98,94 @@
     "                    .enableHiveSupport() \\\n",
     "                    .getOrCreate()\n",
     "sql = spark.sql"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "58c92862",
+   "metadata": {},
    "source": [
     "The class `HiveData` provides a convenient interface to OMOP data stored in Hive.  \n",
     "The OMOP tables can be accessed as attribute and they are represented as [Koalas DataFrames](https://koalas.readthedocs.io/en/latest/getting_started/10min.html#10-minutes-to-Koalas).\n",
     "You simply need to mention your Hive database name."
-   ],
-   "metadata": {}
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "fb2d9d0e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = HiveData(\n",
+    "    \"cse_210038_20221219\",#DB_NAME,\n",
+    "    spark,\n",
+    "    database_type=\"I2B2\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ccca0df",
+   "metadata": {},
+   "source": [
+    "By default, only a subset of tables are added as attributes:"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "source": [
-    "data = HiveData(\n",
-    "    spark, \n",
-    "    DB_NAME\n",
-    ")"
+   "id": "42780520",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['concept',\n",
+       " 'visit_detail',\n",
+       " 'note_deid',\n",
+       " 'person',\n",
+       " 'care_site',\n",
+       " 'visit_occurrence',\n",
+       " 'measurement',\n",
+       " 'procedure_occurrence',\n",
+       " 'condition_occurrence',\n",
+       " 'fact_relationship',\n",
+       " 'concept_relationship']"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
    ],
-   "outputs": [],
-   "metadata": {}
+   "source": [
+    "data.available_tables"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "608cdf81",
+   "metadata": {},
    "source": [
-    "By default, only a subset of tables are added as attributes:"
-   ],
-   "metadata": {}
+    "`Koalas` DataFrames, like `Spark` DataFrames, rely on a *lazy* execution plan: As long as no data needs to be specifically collected, saved or displayed, no code is executed. It is simply saved for a later execution.  \n",
+    "The main interest of Koalas DataFrames is that you can use (most of) the Pandas API:"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "source": [
-    "data.available_tables"
-   ],
+   "id": "6f95d3c1",
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "['care_site',\n",
-       " 'concept',\n",
-       " 'condition_occurrence',\n",
-       " 'person',\n",
-       " 'procedure_occurrence',\n",
-       " 'visit_detail',\n",
-       " 'visit_occurrence']"
-      ]
-     },
-     "metadata": {},
-     "execution_count": 4
-    }
-   ],
-   "metadata": {}
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "`Koalas` DataFrames, like `Spark` DataFrames, rely on a *lazy* execution plan: As long as no data needs to be specifically collected, saved or displayed, no code is executed. It is simply saved for a later execution.  \n",
-    "The main interest of Koalas DataFrames is that you can use (most of) the Pandas API:"
-   ],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "source": [
-    "person = data.person\n",
-    "person.drop(columns = ['person_id']).head()"
-   ],
-   "outputs": [
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    },
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -172,76 +206,46 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>location_id</th>\n",
-       "      <th>year_of_birth</th>\n",
-       "      <th>month_of_birth</th>\n",
-       "      <th>day_of_birth</th>\n",
        "      <th>birth_datetime</th>\n",
        "      <th>death_datetime</th>\n",
        "      <th>gender_source_value</th>\n",
-       "      <th>gender_source_concept_id</th>\n",
        "      <th>cdm_source</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>3347087777</td>\n",
-       "      <td>1949</td>\n",
-       "      <td>8</td>\n",
-       "      <td>2</td>\n",
-       "      <td>1949-08-02</td>\n",
+       "      <td>1946-06-04</td>\n",
        "      <td>NaT</td>\n",
-       "      <td>f</td>\n",
-       "      <td>2008119903</td>\n",
+       "      <td>m</td>\n",
        "      <td>ORBIS</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>9818741928</td>\n",
-       "      <td>1975</td>\n",
-       "      <td>7</td>\n",
-       "      <td>6</td>\n",
-       "      <td>1975-07-06</td>\n",
-       "      <td>NaT</td>\n",
+       "      <td>1940-01-21</td>\n",
+       "      <td>2018-05-07</td>\n",
        "      <td>m</td>\n",
-       "      <td>2008119900</td>\n",
        "      <td>ORBIS</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>3345464435</td>\n",
-       "      <td>1990</td>\n",
-       "      <td>9</td>\n",
-       "      <td>7</td>\n",
-       "      <td>1990-09-07</td>\n",
+       "      <td>1979-04-25</td>\n",
        "      <td>NaT</td>\n",
-       "      <td>f</td>\n",
-       "      <td>2008119903</td>\n",
+       "      <td>m</td>\n",
        "      <td>ORBIS</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>3346060919</td>\n",
-       "      <td>1964</td>\n",
-       "      <td>5</td>\n",
-       "      <td>18</td>\n",
-       "      <td>1964-05-18</td>\n",
+       "      <td>2007-10-13</td>\n",
        "      <td>NaT</td>\n",
        "      <td>f</td>\n",
-       "      <td>2008119903</td>\n",
        "      <td>ORBIS</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>3347197472</td>\n",
-       "      <td>1990</td>\n",
-       "      <td>2</td>\n",
-       "      <td>2</td>\n",
-       "      <td>1990-02-02</td>\n",
+       "      <td>1964-12-27</td>\n",
        "      <td>NaT</td>\n",
-       "      <td>m</td>\n",
-       "      <td>2008119900</td>\n",
+       "      <td>f</td>\n",
        "      <td>ORBIS</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -249,23 +253,30 @@
        "</div>"
       ],
       "text/plain": [
-       "   location_id  year_of_birth  month_of_birth  day_of_birth birth_datetime death_datetime gender_source_value  gender_source_concept_id cdm_source\n",
-       "0   3347087777           1949               8             2     1949-08-02            NaT                   f                2008119903      ORBIS\n",
-       "1   9818741928           1975               7             6     1975-07-06            NaT                   m                2008119900      ORBIS\n",
-       "2   3345464435           1990               9             7     1990-09-07            NaT                   f                2008119903      ORBIS\n",
-       "3   3346060919           1964               5            18     1964-05-18            NaT                   f                2008119903      ORBIS\n",
-       "4   3347197472           1990               2             2     1990-02-02            NaT                   m                2008119900      ORBIS"
+       "  birth_datetime death_datetime gender_source_value cdm_source\n",
+       "0     1946-06-04            NaT                   m      ORBIS\n",
+       "1     1940-01-21     2018-05-07                   m      ORBIS\n",
+       "2     1979-04-25            NaT                   m      ORBIS\n",
+       "3     2007-10-13            NaT                   f      ORBIS\n",
+       "4     1964-12-27            NaT                   f      ORBIS"
       ]
      },
+     "execution_count": 4,
      "metadata": {},
-     "execution_count": 5
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "person = data.person\n",
+    "person.drop(columns = ['person_id']).head()"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
+   "id": "124f6976",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from datetime import datetime\n",
     "\n",
@@ -277,104 +288,144 @@
     "    .person_id\n",
     "    .count()\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "465b5c9b",
+   "metadata": {},
    "source": [
     "Once data has been sufficiently aggregated, it can be converted back to Pandas, e.g. for plotting."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "source": [
-    "stats_pd = stats.to_pandas()"
+   "execution_count": 6,
+   "id": "dbfce661",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "is_over_50\n",
+       "True     132794\n",
+       "False     66808\n",
+       "Name: person_id, dtype: int64"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
    ],
-   "outputs": [],
-   "metadata": {}
+   "source": [
+    "stats_pd = stats.to_pandas()\n",
+    "stats_pd"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "9ef4977a",
+   "metadata": {},
    "source": [
     "Similarily, if you want to work on the `Spark` DataFrame instead, a similar method is available:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
+   "id": "21fd5207",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "person_spark = person.to_spark()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "3e519c27",
+   "metadata": {},
    "source": [
     "## Persisting/Reading a sample to/from disk: `PandasData`\n",
     "\n",
     "Working with Pandas DataFrame is, when possible, more convenient.  \n",
     "You have the possibility to save your database or at least a subset of it.  \n",
     "Doing so allows you to work on it later without having to go through `Spark` again.  "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "65f4cbb0",
+   "metadata": {},
    "source": [
     "!!! warning \"Careful with cohort size\"\n",
     "     Do not save it if your cohort is **big**: This saves **all** available tables on disk."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "e552facc",
+   "metadata": {},
    "source": [
     "For instance, let us define a dummy subset of 1000 patients:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
+   "id": "1d60bed9",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "visits = data.visit_occurrence\n",
     "\n",
     "selected_visits = (\n",
     "    visits\n",
-    "    .loc[visits[\"stay_source_value\"] == \"MCO\"]\n",
+    "    .loc[visits[\"visit_source_value\"] == \"urgence\"]\n",
     ")\n",
     "\n",
     "sample_patients = (\n",
     "    selected_visits[\"person_id\"]\n",
     "    .drop_duplicates()\n",
     "    .head(1000)\n",
-    "    .to_list()\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "684d4b0b",
+   "metadata": {},
    "source": [
     "And save every table restricted to this small cohort as a `parquet` file:"
-   ],
-   "metadata": {}
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "90471c76-def1-45c6-89d9-d3a7710ad91e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MY_FOLDER_PATH = \"./test_cohort\""
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "97678c2a",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import os\n",
     "\n",
     "folder = os.path.abspath(MY_FOLDER_PATH)\n",
-    "os.makedirs(folder, exist_ok=True)\n",
     "\n",
     "tables_to_save = [\"person\", \"visit_detail\", \"visit_occurrence\"]\n",
     "\n",
@@ -383,12 +434,12 @@
     "    tables=tables_to_save,\n",
     "    person_ids=sample_patients\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "88ead263",
+   "metadata": {},
    "source": [
     "Once you saved some data to disk, a dedicated class can be used to access it:  \n",
     "The class `PandasData` can be used to load OMOP data from a folder containing several parquet files. The tables\n",
@@ -396,72 +447,78 @@
     "\n",
     "**Warning**: in this case, the whole table will be loaded into memory on a single jupyter server. Consequently it is advised\n",
     "to only use this for small datasets."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 11,
+   "id": "87b66bfe",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "data = PandasData(folder)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "source": [
-    "data.available_tables"
-   ],
+   "execution_count": 12,
+   "id": "aeee7ebc",
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
-       "['visit_occurrence', 'visit_detail', 'person']"
+       "['visit_detail', 'visit_occurrence', 'person']"
       ]
      },
+     "execution_count": 12,
      "metadata": {},
-     "execution_count": 6
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "data.available_tables"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 13,
+   "id": "5798a8ed",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "type: <class 'pandas.core.frame.DataFrame'>\n",
+      "shape: (1000, 5)\n"
+     ]
+    }
+   ],
    "source": [
     "person = data.person\n",
     "print(f\"type: {type(person)}\")\n",
     "print(f\"shape: {person.shape}\")"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "type: <class 'pandas.core.frame.DataFrame'>\n",
-      "shape: (1000, 10)\n"
-     ]
-    }
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "6dba4d52",
+   "metadata": {},
    "source": [
     "## Loading from PostGres: `PostgresData`\n",
     "\n",
     "OMOP data can be stored in a PostgreSQL database. The `PostgresData` class provides a convinient interface to it.\n",
     "\n",
     "**Note :** this class relies on the file `~/.pgpass` that contains your identifiers for several databases."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
+   "id": "a8486d1f",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "data = PostgresData(\n",
     "    dbname=DB, \n",
@@ -470,59 +527,14 @@
     ")\n",
     "\n",
     "data.read_sql(\"select count(*) from person\")"
-   ],
-   "outputs": [
-    {
-     "output_type": "execute_result",
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>count</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>12688670</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "      count\n",
-       "0  12688670"
-      ]
-     },
-     "metadata": {},
-     "execution_count": 15
-    }
-   ],
-   "metadata": {}
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "scikit_thomas",
    "language": "python",
-   "name": "python3"
+   "name": "scikit_thomas"
   },
   "language_info": {
    "codemirror_mode": {
@@ -534,7 +546,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.16"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/eds_scikit/biology/utils/config.py
+++ b/eds_scikit/biology/utils/config.py
@@ -53,6 +53,12 @@ def create_config_from_stats(
             )
             pass
 
+    if "care_site_short_name" in my_custom_config.columns:
+        # Keep only the row computed from every care site
+        my_custom_config = my_custom_config[
+            my_custom_config.care_site_short_name == "ALL"
+        ]
+
     os.makedirs(CONFIGS_PATH, exist_ok=True)
 
     my_custom_config.to_csv("{}/{}.csv".format(CONFIGS_PATH, config_name), index=False)
@@ -83,6 +89,6 @@ def list_all_configs() -> List[str]:
     """
     registered = list(registry.data.get_all().keys())
     configs = [
-        r.split(".")[-1] for r in registered if r.startswith["get_biology_config"]
+        r.split(".")[-1] for r in registered if r.startswith("get_biology_config")
     ]
     return configs

--- a/eds_scikit/io/data_quality.py
+++ b/eds_scikit/io/data_quality.py
@@ -1,0 +1,17 @@
+import pandas as pd
+from pyspark.sql import DataFrame
+from pyspark.sql.functions import col, when
+
+
+def clean_dates(df: DataFrame) -> DataFrame:
+    dates = [
+        col for col, dtype in df.dtypes if dtype in {"date", "datetime", "timestamp"}
+    ]
+    for date in dates:
+        df = df.withColumn(
+            date,
+            when(
+                (col(date) > pd.Timestamp.max) | (col(date) < pd.Timestamp.min), None
+            ).otherwise(col(date)),
+        )
+    return df


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

3 small fixes:

## Saving tables locally

In spark client or cluster mode, saving a table as parquet won't work because of permission error: executors and driver aren't the same user.  

#### How its solved:
Tables are first collected, and then saved locally by the driver only.  

## Incorrect timestamp error

When collecting tables, `pyarrow` throws an error when stumbling upon incorrect timestamps (smaller than `pd.Timestamp.min` or bigger than `pd.Timestamp.max`).  

#### How it's solved

A filtering is done in `HiveData`, which remplace incorrect timestamps 

## Biology configuration file

When creating a configuration file via `create_config_from_stats`, one row per code AND care site is created, along with a line aggregating all care sites. We only want to keep this row (identified by `df.care_site_short_name == "ALL"`)

#### How it's solved

Filtering, when necessary, on the `care_site_short_name` column

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
