### PR TITLE
Fix: Switch default `to_koalas` in `HiveData._read_table`. to False

### DIFF
--- a/eds_scikit/io/hive.py
+++ b/eds_scikit/io/hive.py
@@ -194,7 +194,7 @@ class HiveData(BaseData):  # pragma: no cover
         return unique_ids, filtering_df
 
     def _read_table(
-        self, table_name, person_ids=None, to_koalas: bool = True
+        self, table_name, person_ids=None, to_koalas: bool = False
     ) -> DataFrame:
 
         if to_koalas:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

The `to_koalas` argument has been deprecated in `_read_table` since it wasn't used. Returning koalas DataFrame during this step allows for more predictable behavior and fewer worries due to OOM errors.

When `to_koalas` is set to True, we raise a warning to indicate that this argument is not used. Since this argument is True by default, we raise this warning for every table to be read, which is unpleasant for the user.

Therefore, this PR suggests setting `to_koalas` to False by default.

<!--- Describe the changes. -->

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
