### PR TITLE
chore: cap pip to 23

### DIFF
--- a/.github/workflows/publish_doc.yml
+++ b/.github/workflows/publish_doc.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.7'
+      - name: Cap pip version
+        run: pip install -u "pip<23"
       - run: pip install .[doc]
       - name: Set up Git
         run: |

--- a/.github/workflows/publish_doc.yml
+++ b/.github/workflows/publish_doc.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version: '3.7'
       - name: Cap pip version
-        run: pip install -u "pip<23"
+        run: pip install -U "pip<23"
       - run: pip install .[doc]
       - name: Set up Git
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.7"
+    - name: Cap pip version
+      run: pip install -u "pip<23"
     - name: Install build dependencies
       run: >-
         python -m
@@ -39,6 +41,8 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.7'
+    - name: Cap pip version
+      run: pip install -u "pip<23"
     - name: Install dependencies
       run: pip install .[doc]
     - name: Set up Git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         python-version: "3.7"
     - name: Cap pip version
-      run: pip install -u "pip<23"
+      run: pip install -U "pip<23"
     - name: Install build dependencies
       run: >-
         python -m
@@ -42,7 +42,7 @@ jobs:
       with:
         python-version: '3.7'
     - name: Cap pip version
-      run: pip install -u "pip<23"
+      run: pip install -U "pip<23"
     - name: Install dependencies
       run: pip install .[doc]
     - name: Set up Git

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -85,10 +85,10 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: "3.7"
+    - name: Cap pip version
+      run: pip install -u "pip<23"
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade "pip<23"
-        pip install .[doc]
+      run: pip install .[doc]
     - name: Build documentation
       run: |
         mkdocs build --clean

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -86,7 +86,7 @@ jobs:
       with:
         python-version: "3.7"
     - name: Cap pip version
-      run: pip install -u "pip<23"
+      run: pip install -U "pip<23"
     - name: Install dependencies
       run: pip install .[doc]
     - name: Build documentation

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ You can install eds-scikit via `pip`:
 pip install "eds-scikit[aphp]"
 ```
 
+:warning: If you get an an error during installation, please try downgrading pip via `pip install -U "pip<23" before install `eds-scikit`
+
 :warning: If you don't work in AP-HP's ecosystem (EDS), please install via:
 
 ```bash

--- a/build_tools/github/install.sh
+++ b/build_tools/github/install.sh
@@ -1,3 +1,4 @@
 #!/bin/bash -e
 
+pip install -U "pip<23"
 pip install --progress-bar off --upgrade ".[dev, doc]"

--- a/build_tools/github/test.sh
+++ b/build_tools/github/test.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -x
 
-pip install -u "pip<23"
+pip install -U "pip<23"
 python -m pytest --pyargs tests -m "" --cov=eds_scikit

--- a/build_tools/github/test.sh
+++ b/build_tools/github/test.sh
@@ -1,3 +1,4 @@
 #!/bin/bash -x
 
+pip install -u "pip<23"
 python -m pytest --pyargs tests -m "" --cov=eds_scikit

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ As an example, the following figure was obtained using various functionalities f
 
             Follow this [installation guide](https://techoral.com/blog/java/openjdk-install-windows.html)
 
-You can install eds-scikit by cloning the git repository:
+You can install eds-scikit via pip:
 
 <div class="termy">
 
@@ -72,6 +72,9 @@ color:green Successfully installed eds_scikit !
 ```
 
 </div>
+
+!!! warning "Possible issue with pip"
+    If you get an an error during installation, please try downgrading pip via `pip install -U "pip<23"` before install `eds-scikit`
 
 !!! danger "Improving performances on distributed data"
       It is highly recommanded (but not mandatory) to use the helper function `eds_scikit.improve_performances` to optimaly configure PySpark and Koalas. You can simply call

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,7 +96,6 @@ plugins:
   - bibtex:
       #bib_file: "docs/references.bib"
       bib_dir: "./"
-      recursive: true
   - gen-files:
       scripts:
         - docs/generate_reference.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ doc = [
     "mike==1.1.2",
     "nbformat==5.7.0",
     "mkdocs-autorefs==0.3.1",
-    "mkdocs-bibtex-recursive==2.8.15",
+    "mkdocs-bibtex==2.8.16",
     "mkdocs-charts-plugin==0.0.8",
     "mkdocs-gen-files==0.3.5",
     "mkdocs-img2fig-plugin==0.9.3",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

Since pip v23, some legacy install via `setup.py` fails (In our case `pyspark`).  
This PR caps the pip version to avoid this issue.
 
## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [ ] If this PR is a bug fix, the bug is documented in the test suite.
- [ ] Changes were documented in the changelog (pending section).
- [ ] If necessary, changes were made to the documentation (eg new pipeline).
