### PR TITLE
Allow person_ids arg in HiveData read_table

### DIFF
--- a/eds_scikit/io/hive.py
+++ b/eds_scikit/io/hive.py
@@ -223,11 +223,11 @@ class HiveData(BaseData):  # pragma: no cover
                 table=table_name,
             )
 
-        df = df.to_koalas()
-
-        person_ids = person_ids or self.person_ids
+        person_ids = person_ids or self.person_ids_df
         if "person_id" in df.columns and person_ids is not None:
             df = df.join(person_ids, on="person_id", how="inner")
+
+        df = df.to_koalas()
 
         df = clean_dates(df)
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -71,6 +71,10 @@ def test_HiveData(spark_session):
     person = data.person
     assert isinstance(person, ks.DataFrame)
     assert person.shape[0] > 2
+    
+    person_ids = pd.Series([2], name="person_id")
+    data_filtered = io.HiveData(database_name=DATABASE, spark_session=spark_session, person_ids=person_ids)
+    assert data_filtered.person.shape[0] == 1
 
 
 def test_clean_date():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -71,9 +71,11 @@ def test_HiveData(spark_session):
     person = data.person
     assert isinstance(person, ks.DataFrame)
     assert person.shape[0] > 2
-    
+
     person_ids = pd.Series([2], name="person_id")
-    data_filtered = io.HiveData(database_name=DATABASE, spark_session=spark_session, person_ids=person_ids)
+    data_filtered = io.HiveData(
+        database_name=DATABASE, spark_session=spark_session, person_ids=person_ids
+    )
     assert data_filtered.person.shape[0] == 1
 
 


### PR DESCRIPTION
## Description
When using `HiveData` with the `person_ids` argument, calling a table (i.e. `data.visit_occurrence`) results in an error: `AttributeError: 'set' object has no attribute 'columns'`. 

This is because we're attempting to merge `df` (the table) on `self.person_ids` --which is a set-- and not `self.person_ids_df` --which is the DataFrame of the `person_ids` to keep--.

## Description
https://github.com/aphp/eds-scikit/blob/001fe9bd139fdee10ffc78129bdafcfd9fcfbad8/eds_scikit/io/hive.py#L228
Replace `self.person_ids` by `self.person_ids_df`

https://github.com/aphp/eds-scikit/blob/001fe9bd139fdee10ffc78129bdafcfd9fcfbad8/eds_scikit/io/hive.py#L226
Should be after `df = df.join`, otherwise we're joining a Spark with a Koalas dataframe.

## How to reproduce the bug before fix
```
import pandas as pd
from eds_scikit.io import HiveData
from eds_scikit import improve_performances

spark, sc, sql = improve_performances()

# This will run and return "Number of unique patients: 2"
data = HiveData(
    database_name="cse_210037_20220831",
    database_type="I2B2",
    person_ids=pd.Series(["person_id_1", "person_id_2"])
)

# This will not work
len(data.visit_occurrence)
```

## Error log

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/tmp/ipykernel_8025/3547872499.py in <module>
----> 1 len(data.note_deid)

~/.user_conda/miniconda/envs/myenv/lib/python3.7/site-packages/eds_scikit/io/hive.py in __getattr__(self, table_name)
    374         elif table_name in self.available_tables:
    375             # Add to cache dictionnary during the first call.
--> 376             table = self._read_table(table_name)
    377             self._tables[table_name] = table
    378             return table

~/.user_conda/miniconda/envs/myenv/lib/python3.7/site-packages/eds_scikit/io/hive.py in _read_table(self, table_name, person_ids, to_koalas)
    228         person_ids = person_ids or self.person_ids
    229         if "person_id" in df.columns and person_ids is not None:
--> 230             df = df.join(person_ids, on="person_id", how="inner")
    231
    232         df = clean_dates(df)

~/.user_conda/miniconda/envs/myenv/lib/python3.7/site-packages/databricks/koalas/frame.py in join(self, right, on, how, lsuffix, rsuffix)
   7889             common = list(self.columns.intersection([right.name]))
   7890         else:
-> 7891             common = list(self.columns.intersection(right.columns))
   7892         if len(common) > 0 and not lsuffix and not rsuffix:
   7893             raise ValueError(

AttributeError: 'set' object has no attribute 'columns'
```

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [ ] Changes were documented in the changelog (pending section).
- [ ] If necessary, changes were made to the documentation (eg new pipeline).
