### PR TITLE
Remove empty path

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,7 +57,6 @@ nav:
       - Generating inclusion/exclusion flowchart: functionalities/plotting/flowchart.ipynb
       - Age pyramid: functionalities/plotting/age_pyramid.md
   - Recipes:
-    - Generating inclusion/exclusion flowchart: recipes/flowchart.ipynb
     - Saving small cohorts locally: recipes/small-cohorts.ipynb
     # - Cross-tagging concepts between two DataFrames: recipes/diabetes.ipynb
   - Resources:


### PR DESCRIPTION
The page for "Generation of an inclusion/exclusion flowchart" was moved from _plotting_ to _recipes_ in the doc, but the old ref was kept in `mkdocs.yml`, leading to a "404 File not found" error on the GitHub pages